### PR TITLE
change 'latestChangeset' to 'latestCommit'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,5 @@ notifications:
     on_success: change
     on_failure: always
     on_start: never
+git:
+  depth: 100

--- a/src/main/groovy/nebula/plugin/stash/tasks/MergeBuiltPullRequestsTask.groovy
+++ b/src/main/groovy/nebula/plugin/stash/tasks/MergeBuiltPullRequestsTask.groovy
@@ -14,10 +14,10 @@ class MergeBuiltPullRequestsTask extends StashTask {
             for (def pr : pullRequests) {
                 println "PR : ${pr.dump()}"
                 assert(pr.containsKey("fromRef"))
-                assert(pr.fromRef.containsKey("latestChangeset"))
+                assert(pr.fromRef.containsKey("latestCommit"))
                 def originBranch = pr.fromRef.displayId
                 logger.info("Checking if pull request from $originBranch (pr id ${pr.id}, version ${pr.version}) can be closed. Pulling builds for current commit of branch.")
-                List<Map> builds = stash.getBuilds(pr.fromRef.latestChangeset)
+                List<Map> builds = stash.getBuilds(pr.fromRef.latestCommit)
                 if(builds.size() == 0) {
                     logger.info("pr id ${pr.id}, version ${pr.version} has no builds, so it can't be closed")
                 }

--- a/src/main/groovy/nebula/plugin/stash/tasks/OpenPostPullRequestIfNotOnBranchTask.groovy
+++ b/src/main/groovy/nebula/plugin/stash/tasks/OpenPostPullRequestIfNotOnBranchTask.groovy
@@ -38,7 +38,7 @@ class OpenPostPullRequestIfNotOnBranchTask extends StashTask {
                 Map result = matchingBranches.find {
                     it.displayId == prFromBranch
                 }
-                assert result.latestChangeset.startsWith(prCommit) // prCommit may be the short commit hash, so account for that
+                assert result.latestCommit.startsWith(prCommit) // prCommit may be the short commit hash, so account for that
 
                 // make sure there isn't already a PR for this
                 def openPrs = stash.getPullRequests(prToBranch, "OPEN", null)

--- a/src/test/groovy/nebula/plugin/stash/tasks/MergeBuiltPullRequestsTaskTest.groovy
+++ b/src/test/groovy/nebula/plugin/stash/tasks/MergeBuiltPullRequestsTaskTest.groovy
@@ -70,17 +70,17 @@ class MergeBuiltPullRequestsTaskFuncTest {
 
     @Test
     public void mergeBuiltPullRequest() {
-        def pr = [id:1L, version: 0, fromRef: [latestChangeset: "abc123"]]
+        def pr = [id:1L, version: 0, fromRef: [latestCommit: "abc123"]]
         def build = [key: StashRestApi.RPM_BUILD_KEY, state: StashRestApi.SUCCESSFUL_BUILD_STATE, url: "http://netflix.com/"]
         when(mockStash.getPullRequests(task.targetBranch, "OPEN", "OLDEST")).thenReturn([pr])
-        when(mockStash.getBuilds(pr.fromRef.latestChangeset)).thenReturn([build])
+        when(mockStash.getBuilds(pr.fromRef.latestCommit)).thenReturn([build])
         when(mockStash.mergePullRequest([id: pr.id, version: pr.version])).thenReturn(null)
         when(mockStash.commentPullRequest(eq(pr.id), anyString())).thenReturn(null)
 
         task.execute()
 
         verify(mockStash).getPullRequests(eq(task.targetBranch), eq("OPEN"), eq("OLDEST"))
-        verify(mockStash).getBuilds(eq(pr.fromRef.latestChangeset))
+        verify(mockStash).getBuilds(eq(pr.fromRef.latestCommit))
         verify(mockStash).mergePullRequest([id: pr.id, version: pr.version])
         verify(mockStash).commentPullRequest(eq(pr.id), anyString())
         verify(mockStash, never()).declinePullRequest([id: pr.id, version: pr.version])
@@ -88,17 +88,17 @@ class MergeBuiltPullRequestsTaskFuncTest {
 
     @Test
     public void dontDeclineFailedBuildPullRequest() { // EDGE-1738 : don't decline reopened PRs
-        def pr = [id:1L, version: 0, fromRef: [latestChangeset: "abc123"]]
+        def pr = [id:1L, version: 0, fromRef: [latestCommit: "abc123"]]
         def build = [key: StashRestApi.RPM_BUILD_KEY, state: StashRestApi.FAILED_BUILD_STATE, url: "http://netflix.com/"]
         when(mockStash.getPullRequests(task.targetBranch, "OPEN", "OLDEST")).thenReturn([pr])
-        when(mockStash.getBuilds(pr.fromRef.latestChangeset)).thenReturn([build])
+        when(mockStash.getBuilds(pr.fromRef.latestCommit)).thenReturn([build])
         when(mockStash.mergePullRequest([id: pr.id, version: pr.version])).thenReturn(null)
         when(mockStash.commentPullRequest(eq(pr.id), anyString())).thenReturn(null)
 
         task.execute()
 
         verify(mockStash).getPullRequests(eq(task.targetBranch), eq("OPEN"), eq("OLDEST"))
-        verify(mockStash).getBuilds(eq(pr.fromRef.latestChangeset))
+        verify(mockStash).getBuilds(eq(pr.fromRef.latestCommit))
         verify(mockStash, never()).declinePullRequest([id: pr.id, version: pr.version])
         verify(mockStash, never()).commentPullRequest(eq(pr.id), anyString())
         verify(mockStash, never()).mergePullRequest([id: pr.id, version: pr.version])
@@ -106,20 +106,20 @@ class MergeBuiltPullRequestsTaskFuncTest {
     
     @Test
     public void mergeBuiltPullRequestWithSingleReviewerNotApproved() { //nothing should get processed, task should pass
-        def pr = [id:1, version: 0, fromRef: [latestChangeset: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
-                  toRef: [latestChangeset: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+        def pr = [id:1, version: 0, fromRef: [latestCommit: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+                  toRef: [latestCommit: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
                     reviewers : [[approved : false, user : [displayName : "Bob Reviewer"]]]
         ]
         def build = [key: StashRestApi.RPM_BUILD_KEY, state: StashRestApi.SUCCESSFUL_BUILD_STATE, url: "http://netflix.com/"]
         when(mockStash.getPullRequests(task.targetBranch, "OPEN", "OLDEST")).thenReturn([pr])
-        when(mockStash.getBuilds(pr.fromRef.latestChangeset)).thenReturn([build])
+        when(mockStash.getBuilds(pr.fromRef.latestCommit)).thenReturn([build])
         when(mockStash.mergePullRequest([id: pr.id, version: pr.version])).thenReturn(null)
         when(mockStash.commentPullRequest(eq(pr.id), anyString())).thenReturn(null)
 
         task.execute()
 
         verify(mockStash).getPullRequests(eq(task.targetBranch), eq("OPEN"), eq("OLDEST"))
-        verify(mockStash).getBuilds(eq(pr.fromRef.latestChangeset))
+        verify(mockStash).getBuilds(eq(pr.fromRef.latestCommit))
         verify(mockStash, never()).mergePullRequest([id: pr.id, version: pr.version])
         verify(mockStash, never()).commentPullRequest(eq(pr.id), anyString())
         verify(mockStash, never()).declinePullRequest([id: pr.id, version: pr.version])
@@ -127,21 +127,21 @@ class MergeBuiltPullRequestsTaskFuncTest {
 
     @Test
     public void syncNextPullRequestWithMultipleReviewersNotApproved() { //nothing should get processed, task should pass
-        def pr = [id:1, version: 0, fromRef: [latestChangeset: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
-                  toRef: [latestChangeset: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+        def pr = [id:1, version: 0, fromRef: [latestCommit: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+                  toRef: [latestCommit: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
                   reviewers : [[approved : true, user : [displayName : "Bob Reviewer"]], [approved : false, user : [displayName : "Joe Reviewer"]]
                            ]
         ]
         def build = [key: StashRestApi.RPM_BUILD_KEY, state: StashRestApi.SUCCESSFUL_BUILD_STATE, url: "http://netflix.com/"]
         when(mockStash.getPullRequests(task.targetBranch, "OPEN", "OLDEST")).thenReturn([pr])
-        when(mockStash.getBuilds(pr.fromRef.latestChangeset)).thenReturn([build])
+        when(mockStash.getBuilds(pr.fromRef.latestCommit)).thenReturn([build])
         when(mockStash.mergePullRequest([id: pr.id, version: pr.version])).thenReturn(null)
         when(mockStash.commentPullRequest(eq(pr.id), anyString())).thenReturn(null)
 
         task.execute()
 
         verify(mockStash).getPullRequests(eq(task.targetBranch), eq("OPEN"), eq("OLDEST"))
-        verify(mockStash).getBuilds(eq(pr.fromRef.latestChangeset))
+        verify(mockStash).getBuilds(eq(pr.fromRef.latestCommit))
         verify(mockStash, never()).mergePullRequest([id: pr.id, version: pr.version])
         verify(mockStash, never()).commentPullRequest(eq(pr.id), anyString())
         verify(mockStash, never()).declinePullRequest([id: pr.id, version: pr.version])
@@ -149,20 +149,20 @@ class MergeBuiltPullRequestsTaskFuncTest {
 
     @Test
     public void syncNextPullRequestWithSingleReviewerApproved() { //nothing should get processed, task should pass
-        def pr = [id:1L, version: 0, fromRef: [latestChangeset: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
-                  toRef: [latestChangeset: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+        def pr = [id:1L, version: 0, fromRef: [latestCommit: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+                  toRef: [latestCommit: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
                   reviewers : [[approved : true, user : [displayName : "Bob Reviewer"]]]
         ]
         def build = [key: StashRestApi.RPM_BUILD_KEY, state: StashRestApi.SUCCESSFUL_BUILD_STATE, url: "http://netflix.com/"]
         when(mockStash.getPullRequests(task.targetBranch, "OPEN", "OLDEST")).thenReturn([pr])
-        when(mockStash.getBuilds(pr.fromRef.latestChangeset)).thenReturn([build])
+        when(mockStash.getBuilds(pr.fromRef.latestCommit)).thenReturn([build])
         when(mockStash.mergePullRequest([id: pr.id, version: pr.version])).thenReturn(null)
         when(mockStash.commentPullRequest(eq(pr.id), anyString())).thenReturn(null)
 
         task.execute()
 
         verify(mockStash).getPullRequests(eq(task.targetBranch), eq("OPEN"), eq("OLDEST"))
-        verify(mockStash).getBuilds(eq(pr.fromRef.latestChangeset))
+        verify(mockStash).getBuilds(eq(pr.fromRef.latestCommit))
         verify(mockStash).mergePullRequest([id: pr.id, version: pr.version])
         verify(mockStash).commentPullRequest(eq(pr.id), anyString())
         verify(mockStash, never()).declinePullRequest([id: pr.id, version: pr.version])
@@ -170,21 +170,21 @@ class MergeBuiltPullRequestsTaskFuncTest {
 
     @Test
     public void syncNextPullRequestWithMultipleReviewersApproved() { //nothing should get processed, task should pass
-        def pr = [id:1L, version: 0, fromRef: [latestChangeset: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
-                  toRef: [latestChangeset: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+        def pr = [id:1L, version: 0, fromRef: [latestCommit: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+                  toRef: [latestCommit: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
                   reviewers : [[approved : true, user : [displayName : "Bob Reviewer"]], [approved : true, user : [displayName : "Joe Reviewer"]]
                   ]
         ]
         def build = [key: StashRestApi.RPM_BUILD_KEY, state: StashRestApi.SUCCESSFUL_BUILD_STATE, url: "http://netflix.com/"]
         when(mockStash.getPullRequests(task.targetBranch, "OPEN", "OLDEST")).thenReturn([pr])
-        when(mockStash.getBuilds(pr.fromRef.latestChangeset)).thenReturn([build])
+        when(mockStash.getBuilds(pr.fromRef.latestCommit)).thenReturn([build])
         when(mockStash.mergePullRequest([id: pr.id, version: pr.version])).thenReturn(null)
         when(mockStash.commentPullRequest(eq(pr.id), anyString())).thenReturn(null)
 
         task.execute()
 
         verify(mockStash).getPullRequests(eq(task.targetBranch), eq("OPEN"), eq("OLDEST"))
-        verify(mockStash).getBuilds(eq(pr.fromRef.latestChangeset))
+        verify(mockStash).getBuilds(eq(pr.fromRef.latestCommit))
         verify(mockStash).mergePullRequest([id: pr.id, version: pr.version])
         verify(mockStash).commentPullRequest(eq(pr.id), anyString())
         verify(mockStash, never()).declinePullRequest([id: pr.id, version: pr.version])

--- a/src/test/groovy/nebula/plugin/stash/tasks/OpenPostPullRequestIfNotOnBranchTaskTest.groovy
+++ b/src/test/groovy/nebula/plugin/stash/tasks/OpenPostPullRequestIfNotOnBranchTaskTest.groovy
@@ -159,7 +159,7 @@ class OpenPostPullRequestIfNotOnBranchTaskFunctionalTest {
     public void branchAlreadyHasAPullRequest() {
         project.tasks.openPostPullRequestIfNotOnBranchTask.stash = mockStash
         def branchInfoResponse = [ [id : "refs/heads/branch-a", displayId : "branch-a"] ]
-        def matchingBranchResponse = [ [id : "refs/heads/branch-a", displayId : "branch-a", latestChangeset : testCommit] ]
+        def matchingBranchResponse = [ [id : "refs/heads/branch-a", displayId : "branch-a", latestCommit : testCommit] ]
         def openPrsResponse = [ [fromRef : [id: "refs/heads/branch-a"], toRef : [id : "refs/heads/${testBranch}"]] ]
 
         when(mockStash.getBranchInfo(testCommit)).thenReturn(branchInfoResponse)
@@ -175,7 +175,7 @@ class OpenPostPullRequestIfNotOnBranchTaskFunctionalTest {
     public void commitNotHeadOfSourceBranch() {
         project.tasks.openPostPullRequestIfNotOnBranchTask.stash = mockStash
         def branchInfoResponse = [ [id : "refs/heads/branch-a", displayId : "branch-a"] ]
-        def matchingBranchResponse = [ [id : "refs/heads/branch-a", displayId : "branch-a", latestChangeset : "notExpectedCommit"] ]
+        def matchingBranchResponse = [ [id : "refs/heads/branch-a", displayId : "branch-a", latestCommit : "notExpectedCommit"] ]
         def openPrsResponse = []
         def postPullRequestResponse = [ link : [url : "http://foo.com/123"] ]
 
@@ -195,7 +195,7 @@ class OpenPostPullRequestIfNotOnBranchTaskFunctionalTest {
     public void successfullyOpenPullRequest() {
         project.tasks.openPostPullRequestIfNotOnBranchTask.stash = mockStash
         def branchInfoResponse = [ [id : "refs/heads/branch-a", displayId : "branch-a"] ]
-        def matchingBranchResponse = [ [id : "refs/heads/branch-a", displayId : "branch-a", latestChangeset : testCommit] ]
+        def matchingBranchResponse = [ [id : "refs/heads/branch-a", displayId : "branch-a", latestCommit : testCommit] ]
         def openPrsResponse = []
         def postPullRequestResponse = [ link : [url : "http://foo.com/123"] ]
 

--- a/src/test/groovy/nebula/plugin/stash/tasks/PostPullRequestTaskTest.groovy
+++ b/src/test/groovy/nebula/plugin/stash/tasks/PostPullRequestTaskTest.groovy
@@ -126,7 +126,7 @@ class PostPullRequestTaskFunctionalTest {
     
     @Test
     public void postPullRequest() {
-        def pr = [id:1, version: 0, fromRef: [latestChangeset: "abc123"], toRef: [latestChangeset: "def456"]]
+        def pr = [id:1, version: 0, fromRef: [latestCommit: "abc123"], toRef: [latestCommit: "def456"]]
         when(mockStash.postPullRequest(anyString(), anyString(), anyString(), anyString(), anyString())).thenReturn(pr)
         project.tasks.postPullRequest.execute()
         verify(mockStash).postPullRequest(anyString(), anyString(), anyString(), anyString(), anyString())
@@ -134,7 +134,7 @@ class PostPullRequestTaskFunctionalTest {
 
     @Test(expected = GradleException.class)
     public void postPullRequestFails() {
-        def pr = [id:1, version: 0, fromRef: [latestChangeset: "abc123"], toRef: [latestChangeset: "def456"]]
+        def pr = [id:1, version: 0, fromRef: [latestCommit: "abc123"], toRef: [latestCommit: "def456"]]
         when(mockStash.postPullRequest(anyString(), anyString(), anyString(), anyString(), anyString())).thenThrow(new GradleException("mock exception"))
         project.tasks.postPullRequest.execute()
     }    

--- a/src/test/groovy/nebula/plugin/stash/tasks/SyncNextPullRequestTaskTest.groovy
+++ b/src/test/groovy/nebula/plugin/stash/tasks/SyncNextPullRequestTaskTest.groovy
@@ -65,7 +65,7 @@ class SyncNextPullRequestTaskFunctionalTest {
     
     @Test
     public void syncNextPullRequest() {
-        def pr = [id:1, version: 0, fromRef: [latestChangeset: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]], toRef: [latestChangeset: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]]]
+        def pr = [id:1, version: 0, fromRef: [latestCommit: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]], toRef: [latestCommit: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]]]
         when(cmd.execute(anyString(), anyString())).thenReturn("abc123")
         when(mockStash.getPullRequests(anyString(), anyString(), anyString())).thenReturn([pr])
         when(mockStash.getPullRequest(anyInt())).thenReturn(pr)
@@ -81,7 +81,7 @@ class SyncNextPullRequestTaskFunctionalTest {
 
     @Test
     public void syncNextPullRequestInvalidPr() { //nothing should get processed, task should pass
-        def pr = [id:1, version: 0, fromRef: [latestChangeset: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]], toRef: [latestChangeset: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]]]
+        def pr = [id:1, version: 0, fromRef: [latestCommit: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]], toRef: [latestCommit: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]]]
         def build = [key: StashRestApi.RPM_BUILD_KEY, state: StashRestApi.INPROGRESS_BUILD_STATE, url: "http://netflix.com/"]
         when(cmd.execute(anyString(), anyString())).thenReturn("abc123")
         when(mockStash.getBuilds(anyString())).thenReturn([build])
@@ -92,7 +92,7 @@ class SyncNextPullRequestTaskFunctionalTest {
     
     @Test
     public void syncNextPullRequestUnableToMerge() { //nothing should get processed, task should pass
-        def pr = [id:1, version: 0, fromRef: [latestChangeset: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]], toRef: [latestChangeset: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]]]
+        def pr = [id:1, version: 0, fromRef: [latestCommit: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]], toRef: [latestCommit: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]]]
         when(cmd.execute(anyString(), anyString())).thenReturn("Automatic merge failed")
         when(mockStash.getPullRequests(anyString(), anyString(), anyString())).thenReturn([pr])
         try {
@@ -107,8 +107,8 @@ class SyncNextPullRequestTaskFunctionalTest {
 
     @Test
     public void syncNextPullRequestWithSingleReviewerNotApproved() { //nothing should get processed, task should pass
-        def pr = [id:1, version: 0, fromRef: [latestChangeset: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
-                  toRef: [latestChangeset: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+        def pr = [id:1, version: 0, fromRef: [latestCommit: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+                  toRef: [latestCommit: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
                     reviewers : [[approved : false, user : [displayName : "Bob Reviewer"]]]
         ]
         when(cmd.execute(anyString(), anyString())).thenReturn("abc123")
@@ -121,8 +121,8 @@ class SyncNextPullRequestTaskFunctionalTest {
 
     @Test
     public void syncNextPullRequestWithMultipleReviewersNotApproved() { //nothing should get processed, task should pass
-        def pr = [id:1, version: 0, fromRef: [latestChangeset: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
-                  toRef: [latestChangeset: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+        def pr = [id:1, version: 0, fromRef: [latestCommit: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+                  toRef: [latestCommit: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
                   reviewers : [[approved : true, user : [displayName : "Bob Reviewer"]], [approved : false, user : [displayName : "Joe Reviewer"]]
                            ]
         ]
@@ -136,8 +136,8 @@ class SyncNextPullRequestTaskFunctionalTest {
 
     @Test
     public void syncNextPullRequestWithSingleReviewerApproved() {
-        def pr = [id:1, version: 0, fromRef: [latestChangeset: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
-                  toRef: [latestChangeset: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+        def pr = [id:1, version: 0, fromRef: [latestCommit: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+                  toRef: [latestCommit: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
                   reviewers : [[approved : true, user : [displayName : "Bob Reviewer"]]]
         ]
         when(cmd.execute(anyString(), anyString())).thenReturn("abc123")
@@ -150,8 +150,8 @@ class SyncNextPullRequestTaskFunctionalTest {
 
     @Test
     public void syncNextPullRequestWithMultipleReviewersApproved() {
-        def pr = [id:1, version: 0, fromRef: [latestChangeset: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
-                  toRef: [latestChangeset: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+        def pr = [id:1, version: 0, fromRef: [latestCommit: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+                  toRef: [latestCommit: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
                   reviewers : [[approved : true, user : [displayName : "Bob Reviewer"]], [approved : true, user : [displayName : "Joe Reviewer"]]
                   ]
         ]
@@ -165,8 +165,8 @@ class SyncNextPullRequestTaskFunctionalTest {
 
     @Test
     public void syncNextPullRequestWithOnlyOneReviewersApproved() {
-        def pr = [id:1, version: 0, fromRef: [latestChangeset: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
-                  toRef: [latestChangeset: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+        def pr = [id:1, version: 0, fromRef: [latestCommit: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+                  toRef: [latestCommit: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
                   reviewers : [[approved : true, user : [displayName : "Bob Reviewer"]], [approved : false, user : [displayName : "Joe Reviewer"]]
                   ]
         ]
@@ -181,8 +181,8 @@ class SyncNextPullRequestTaskFunctionalTest {
 
     @Test
     public void syncNextPullRequestWithAllReviewersApproved() {
-        def pr = [id:1, version: 0, fromRef: [latestChangeset: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
-                  toRef: [latestChangeset: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+        def pr = [id:1, version: 0, fromRef: [latestCommit: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+                  toRef: [latestCommit: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
                   reviewers : [[approved : true, user : [displayName : "Bob Reviewer"]], [approved : true, user : [displayName : "Joe Reviewer"]]
                   ]
         ]
@@ -197,8 +197,8 @@ class SyncNextPullRequestTaskFunctionalTest {
 
     @Test
     public void syncNextPullRequestWithMultipleReviewersNotApprovedRequireOne() { //nothing should get processed, task should pass
-        def pr = [id:1, version: 0, fromRef: [latestChangeset: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
-                  toRef: [latestChangeset: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+        def pr = [id:1, version: 0, fromRef: [latestCommit: "abc123", displayId: "fromDisplayId", repository: [cloneUrl: "abc.com/stash"]],
+                  toRef: [latestCommit: "def456", displayId: "toDisplayId", repository: [cloneUrl: "abc.com/stash"]],
                   reviewers : [[approved : false, user : [displayName : "Bob Reviewer"]], [approved : false, user : [displayName : "Joe Reviewer"]]
                   ]
         ]


### PR DESCRIPTION
Stash/Bitbucket Server version 4.6.3 changes the 'latestChangeset' field to 'latestCommit'.
